### PR TITLE
Change version of lombok in annotation processing

### DIFF
--- a/Chapter10/pom.xml
+++ b/Chapter10/pom.xml
@@ -187,7 +187,7 @@
             <path>
               <groupId>org.projectlombok</groupId>
               <artifactId>lombok</artifactId>
-              <version>1.18.16</version>
+              <version>${lombok.version}</version>
             </path>
           </annotationProcessorPaths>
         </configuration>


### PR DESCRIPTION
In annotation processing a hardcoded older version of lombok was used. Now this is replaced withe the already existing property lombok.version.